### PR TITLE
Feat: Add MRT (Monitoring Of Room Temperature) as MA (Monitoring Appliance) Client Actor

### DIFF
--- a/features/internal/measurement.go
+++ b/features/internal/measurement.go
@@ -110,7 +110,7 @@ func (m *MeasurementCommon) GetConstraintsForFilter(
 	return result, nil
 }
 
-// Get the measuement data for a given measurementId
+// Get the measurements data for a given measurementId
 //
 // Will return nil if no data is available
 func (m *MeasurementCommon) GetDataForId(measurementId model.MeasurementIdType) (
@@ -123,7 +123,7 @@ func (m *MeasurementCommon) GetDataForId(measurementId model.MeasurementIdType) 
 	return &result[0], nil
 }
 
-// Get measuement data for a given filter
+// Get measurements data for a given filter
 //
 // Will return nil if no data is available
 func (m *MeasurementCommon) GetDataForFilter(filter model.MeasurementDescriptionDataType) (

--- a/usecases/api/ma_mrhsf.go
+++ b/usecases/api/ma_mrhsf.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Actor: Monitoring Appliance
-// UseCase: Monitoring of Power Consumption
+// UseCase: Monitoring of Room Heating System Function
 type MaMRHSFInterface interface {
 	api.UseCaseInterface
 

--- a/usecases/api/ma_mrt.go
+++ b/usecases/api/ma_mrt.go
@@ -1,0 +1,13 @@
+package api
+
+import (
+	"github.com/enbility/eebus-go/api"
+)
+
+// Actor: Monitoring Appliance
+// UseCase: Monitoring of Room Temperature
+type MaMRTInterface interface {
+	api.UseCaseInterface
+
+	// Scenario 1
+}

--- a/usecases/cem/ohpcf/public.go
+++ b/usecases/cem/ohpcf/public.go
@@ -7,9 +7,9 @@ import (
 	"github.com/enbility/eebus-go/features/client"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
 	"github.com/enbility/ship-go/logging"
+	"github.com/enbility/ship-go/util"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
-	"github.com/enbility/spine-go/util"
 )
 
 // Returns copy of the SmartEnergyManagementPsDataType data for the given entity.

--- a/usecases/ma/mrhsf/events.go
+++ b/usecases/ma/mrhsf/events.go
@@ -9,7 +9,7 @@ import (
 	"github.com/enbility/spine-go/model"
 )
 
-// HandleEvent handles events for the CRCSF use case
+// HandleEvent handles events for the MRHSF use case
 func (e *MRHSF) HandleEvent(payload spineapi.EventPayload) {
 	if !e.IsCompatibleEntityType(payload.Entity) {
 		return

--- a/usecases/ma/mrt/events.go
+++ b/usecases/ma/mrt/events.go
@@ -1,0 +1,119 @@
+package mrt
+
+import (
+	"github.com/enbility/eebus-go/features/client"
+	"github.com/enbility/eebus-go/usecases/internal"
+	"github.com/enbility/ship-go/logging"
+	"github.com/enbility/ship-go/util"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+)
+
+// HandleEvent handles events for the MRT use case
+func (e *MRT) HandleEvent(payload spineapi.EventPayload) {
+	if !e.IsCompatibleEntityType(payload.Entity) {
+		return
+	}
+
+	if internal.IsEntityConnected(payload) {
+		e.deviceConnected(payload.Entity)
+		return
+	}
+
+	if payload.EventType != spineapi.EventTypeDataChange ||
+		payload.ChangeType != spineapi.ElementChangeUpdate {
+		return
+	}
+
+	switch payload.Data.(type) {
+	case *model.MeasurementDescriptionListDataType:
+		e.deviceMeasurementDescriptionDataUpdate(payload)
+
+	case *model.MeasurementConstraintsListDataType:
+		e.measurementConstraintsDataUpdate(payload)
+
+	case *model.MeasurementListDataType:
+		e.deviceMeasurementDataUpdate(payload)
+	}
+}
+
+func (e *MRT) measurementConstraintsDataUpdate(payload spineapi.EventPayload) {
+	if measurement, err := client.NewMeasurement(e.LocalEntity, payload.Entity); err == nil {
+		// Scenario 1
+		filter := model.MeasurementDescriptionDataType{
+			ScopeType: util.Ptr(model.ScopeTypeTypeRoomAirTemperature),
+		}
+		if measurement.CheckEventPayloadDataForFilter(payload.Data, filter) && e.EventCB != nil {
+			e.EventCB(payload.Ski, payload.Device, payload.Entity, DataUpdateRoomTemperature)
+		}
+	}
+}
+
+func (e *MRT) deviceConnected(entity spineapi.EntityRemoteInterface) {
+	if measurement, err := client.NewMeasurement(e.LocalEntity, entity); err == nil {
+		if !measurement.HasSubscription() {
+			if _, err := measurement.Subscribe(); err != nil {
+				logging.Log().Error(err)
+			}
+		}
+
+		selector := &model.MeasurementDescriptionListDataSelectorsType{
+			ScopeType: util.Ptr(model.ScopeTypeTypeRoomAirTemperature),
+		}
+		if _, err := measurement.RequestDescriptions(selector, nil); err != nil {
+			logging.Log().Error(err)
+		}
+	}
+}
+
+func (e *MRT) deviceMeasurementDescriptionDataUpdate(payload spineapi.EventPayload) {
+	measurement, err := client.NewMeasurement(e.LocalEntity, payload.Entity)
+	if err != nil {
+		logging.Log().Errorf("Error creating measurement client: %v", err)
+		return
+	}
+
+	filter := model.MeasurementDescriptionDataType{
+		ScopeType: util.Ptr(model.ScopeTypeTypeRoomAirTemperature),
+	}
+	measurements, err := measurement.GetDataForFilter(filter)
+	if err != nil || len(measurements) == 0 {
+		logging.Log().Errorf("Error getting measurement data for filter: %v", err)
+		return
+	}
+
+	if measurements[0].MeasurementId == nil {
+		logging.Log().Error("Measurement ID is nil")
+		return
+	}
+
+	// Preform partial reads for measurement constrains and measurements data with
+	// measurementId from the measurement description of the room air temperature.
+	measurementId := *measurements[0].MeasurementId
+
+	measurementsSelector := &model.MeasurementListDataSelectorsType{
+		MeasurementId: &measurementId,
+	}
+	if _, err := measurement.RequestData(measurementsSelector, nil); err != nil {
+		logging.Log().Error("Error getting measurement list values:", err)
+	}
+
+	constraintsSelector := &model.MeasurementConstraintsListDataSelectorsType{
+		MeasurementId: &measurementId,
+	}
+	if _, err := measurement.RequestConstraints(constraintsSelector, nil); err != nil {
+		logging.Log().Error(err)
+	}
+}
+
+func (e *MRT) deviceMeasurementDataUpdate(payload spineapi.EventPayload) {
+	if measurement, err := client.NewMeasurement(e.LocalEntity, payload.Entity); err == nil {
+		// Scenario 1
+		filter := model.MeasurementDescriptionDataType{
+			ScopeType: util.Ptr(model.ScopeTypeTypeRoomAirTemperature),
+		}
+		if measurement.CheckEventPayloadDataForFilter(payload.Data, filter) && e.EventCB != nil {
+			e.EventCB(payload.Ski, payload.Device, payload.Entity, DataUpdateRoomTemperature)
+		}
+	}
+}

--- a/usecases/ma/mrt/public.go
+++ b/usecases/ma/mrt/public.go
@@ -1,0 +1,44 @@
+package mrt
+
+import (
+	"github.com/enbility/eebus-go/api"
+	"github.com/enbility/eebus-go/features/client"
+	"github.com/enbility/ship-go/util"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+)
+
+// Scenario 1
+
+// return the momentary room temperature
+//
+// Parameters:
+//   - entity: the entity of the room
+//
+// Returns:
+//   - the room temperature
+//
+// possible errors:
+//   - ErrDataNotAvailable if room temperature is not available
+//   - and others
+func (e *MRT) RoomTemperature(entity spineapi.EntityRemoteInterface) (float64, error) {
+	if !e.IsCompatibleEntityType(entity) {
+		return 0, api.ErrNoCompatibleEntity
+	}
+
+	measurement, err := client.NewMeasurement(e.LocalEntity, entity)
+	if err != nil {
+		return 0, api.ErrMetadataNotAvailable
+	}
+
+	filter := model.MeasurementDescriptionDataType{
+		ScopeType: util.Ptr(model.ScopeTypeTypeRoomAirTemperature),
+	}
+
+	measurements, err := measurement.GetDataForFilter(filter)
+	if err == nil && len(measurements) == 1 {
+		return measurements[0].Value.GetValue(), nil
+	}
+
+	return 0.0, api.ErrDataNotAvailable
+}

--- a/usecases/ma/mrt/types.go
+++ b/usecases/ma/mrt/types.go
@@ -1,0 +1,17 @@
+package mrt
+
+import "github.com/enbility/eebus-go/api"
+
+const (
+	// Update of the list of remote entities supporting the Use Case
+	//
+	// Use `RemoteEntities` to get the current data
+	UseCaseSupportUpdate api.EventType = "ma-mrt-UseCaseSupportUpdate"
+
+	// Current room temperature
+	//
+	// Use `RoomTemperature` to get the current data
+	//
+	// Use Case MRT, Scenario 1
+	DataUpdateRoomTemperature api.EventType = "ma-mrt-DataUpdateRoomTemperature"
+)

--- a/usecases/ma/mrt/usecase.go
+++ b/usecases/ma/mrt/usecase.go
@@ -1,0 +1,70 @@
+package mrt
+
+import (
+	"github.com/enbility/eebus-go/api"
+	ucapi "github.com/enbility/eebus-go/usecases/api"
+	"github.com/enbility/eebus-go/usecases/usecase"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+	"github.com/enbility/spine-go/spine"
+)
+
+// MRT - Monitoring of Room Temperature Use Case
+type MRT struct {
+	*usecase.UseCaseBase
+}
+
+var _ ucapi.MaMRTInterface = (*MRT)(nil)
+
+// Create a new Monitoring of Room Temperature Use Case
+func NewMRT(
+	localEntity spineapi.EntityLocalInterface,
+	eventCB api.EntityEventCallback,
+) *MRT {
+	validActorTypes := []model.UseCaseActorType{
+		model.UseCaseActorTypeHVACRoom,
+	}
+	validEntityTypes := []model.EntityTypeType{
+		model.EntityTypeTypeHvacRoom,
+	}
+	useCaseScenarios := []api.UseCaseScenario{
+		{
+			Scenario:  model.UseCaseScenarioSupportType(1),
+			Mandatory: true,
+			ServerFeatures: []model.FeatureTypeType{
+				model.FeatureTypeTypeMeasurement,
+			},
+		},
+	}
+
+	usecase := usecase.NewUseCaseBase(
+		localEntity,
+		model.UseCaseActorTypeMonitoringAppliance,
+		model.UseCaseNameTypeMonitoringOfRoomTemperature,
+		"1.0.0",
+		"release",
+		useCaseScenarios,
+		eventCB,
+		UseCaseSupportUpdate,
+		validActorTypes,
+		validEntityTypes,
+	)
+
+	uc := &MRT{
+		UseCaseBase: usecase,
+	}
+
+	_ = spine.Events.Subscribe(uc)
+
+	return uc
+}
+
+func (e *MRT) AddFeatures() {
+	var clientFeatures = []model.FeatureTypeType{
+		model.FeatureTypeTypeMeasurement,
+	}
+
+	for _, feature := range clientFeatures {
+		_ = e.LocalEntity.GetOrAddFeature(feature, model.RoleTypeClient)
+	}
+}


### PR DESCRIPTION
This commit introduces the MRT (Monitoring of Room Temperature) use case  as MA (Monitoring Appliance) Client Actor.

In this use case, the client acts as MA (Monitoring Appliance) actor and it is responsible for monitoring the room air temperature measurements of the server.